### PR TITLE
Feature/extend cycle

### DIFF
--- a/lib/sof/cycle.rb
+++ b/lib/sof/cycle.rb
@@ -165,6 +165,8 @@ module SOF
     # Return the most recent completion date from the supplied array of dates
     def last_completed(dates) = dates.compact.map(&:to_date).max
 
+    def extend_period(_ = nil) = self
+
     # From the supplied anchor date, are there enough in-window completions to
     # satisfy the cycle?
     #

--- a/lib/sof/cycles/within.rb
+++ b/lib/sof/cycles/within.rb
@@ -12,6 +12,14 @@ module SOF
 
       def to_s = "#{volume}x within #{date_range}"
 
+      def extend_period(count)
+        Cycle.for(
+          Parser.load(
+            parser.to_h.merge(period_count: period_count + count)
+          ).to_s
+        )
+      end
+
       def date_range
         return humanized_span unless active?
 

--- a/spec/sof/cycles/calendar_spec.rb
+++ b/spec/sof/cycles/calendar_spec.rb
@@ -32,6 +32,7 @@ module SOF
     it_behaves_like "it computes #final_date(given)",
       given: "1971-01-01", returns: "1971-12-31".to_date
     it_behaves_like "last_completed is", :recent_date
+    it_behaves_like "it cannot be extended"
 
     describe "#recurring?" do
       it "repeats" do

--- a/spec/sof/cycles/end_of_spec.rb
+++ b/spec/sof/cycles/end_of_spec.rb
@@ -39,6 +39,7 @@ module SOF
     it_behaves_like "#as_json returns the notation"
     it_behaves_like "it computes #final_date(given)",
       given: nil, returns: ("2020-01-01".to_date + 17.months).end_of_month
+    it_behaves_like "it cannot be extended"
 
     describe "#last_completed" do
       context "with an activated cycle" do

--- a/spec/sof/cycles/lookback_spec.rb
+++ b/spec/sof/cycles/lookback_spec.rb
@@ -32,6 +32,7 @@ module SOF
     it_behaves_like "it computes #final_date(given)",
       given: "2003-03-08", returns: ("2003-03-08".to_date + 180.days)
     it_behaves_like "last_completed is", :recent_date
+    it_behaves_like "it cannot be extended"
 
     describe "#recurring?" do
       it "repeats" do

--- a/spec/sof/cycles/shared_examples.rb
+++ b/spec/sof/cycles/shared_examples.rb
@@ -51,3 +51,9 @@ shared_examples_for "last_completed is" do |symbol|
     expect(subject.last_completed(dates)).to eq(expected)
   end
 end
+
+shared_examples_for "it cannot be extended" do
+  it "returns itself" do
+    expect(subject.extend_period(999)).to eq(subject)
+  end
+end

--- a/spec/sof/cycles/volume_only_spec.rb
+++ b/spec/sof/cycles/volume_only_spec.rb
@@ -30,6 +30,7 @@ module SOF
     it_behaves_like "it computes #final_date(given)",
       given: "2003-03-08", returns: nil
     it_behaves_like "last_completed is", :recent_date
+    it_behaves_like "it cannot be extended"
 
     describe "#recurring?" do
       it "does not repeat" do

--- a/spec/sof/cycles/within_spec.rb
+++ b/spec/sof/cycles/within_spec.rb
@@ -34,6 +34,17 @@ module SOF
       given: "_", returns: ("2020-08-01".to_date + 180.days)
     it_behaves_like "last_completed is", :too_late
 
+    describe "#extend_period" do
+      it "increases the period by the given amount" do
+        aggregate_failures do
+          expect(cycle.notation).to eq("V2W180DF2020-08-01")
+
+          new_cycle = cycle.extend_period(30)
+          expect(new_cycle.notation).to eq("V2W210DF2020-08-01")
+        end
+      end
+    end
+
     describe "#recurring?" do
       it "does not repeat" do
         expect(cycle).not_to be_recurring


### PR DESCRIPTION
In the case of `Cycles::Within` we need the ability to return cycle notation extended by a passed in period count.

E.g. MQT JTACs normally have a 180 days to accomplish their tasks, which thus have notations like `V1W180DF{some_date}". But they can get a 30 day extension, so:
```
cycle.notation # => "V1W180DF{some_date}"
cycle.notation_extended_by(30) # => "V1W210DF{some_date}"
```

For other Cycle types this just returns the original notation, unchanged.