### PR TITLE
Bug/volume to delay expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.7] - Unreleased
 
+### Added
+
+- `Cycle#considered_dates` to get the subset of `#covered_dates` that are
+  considered for the cycle's calculations.
+
+### Fixed
+
+- `Cycles::Lookback.volume_to_delay_expiration` now computes correctly when the
+  `#considered_dates` is smaller than the `#covered_dates` of the cycle.
+
 ## [0.1.6] - 2024-09-04
 
 ### Added

--- a/lib/sof/cycle.rb
+++ b/lib/sof/cycle.rb
@@ -175,6 +175,10 @@ module SOF
       covered_dates(completion_dates, anchor:).size >= volume
     end
 
+    def considered_dates(completion_dates, anchor: Date.current)
+      covered_dates(completion_dates, anchor:).max_by(volume) { _1 }
+    end
+
     def covered_dates(dates, anchor: Date.current)
       dates.select do |date|
         cover?(date, anchor:)

--- a/lib/sof/cycles/lookback.rb
+++ b/lib/sof/cycles/lookback.rb
@@ -13,8 +13,12 @@ module SOF
       def to_s = "#{volume}x in the prior #{period_count} #{humanized_period}"
 
       def volume_to_delay_expiration(completion_dates, anchor:)
-        oldest_relevant_completion = completion_dates.min
-        [completion_dates.count(oldest_relevant_completion), volume].min
+        relevant_dates = considered_dates(completion_dates, anchor:)
+        return unless satisfied_by?(relevant_dates, anchor:)
+
+        # To move the expiration date, we need to displace each occurance of the
+        # oldest date within #considered_dates.
+        relevant_dates.count(relevant_dates.min)
       end
 
       # "Absent further completions, you go red on this date"

--- a/spec/sof/cycles/lookback_spec.rb
+++ b/spec/sof/cycles/lookback_spec.rb
@@ -118,5 +118,55 @@ module SOF
         end
       end
     end
+
+    describe "#volume_to_delay_expiration(completed_dates, anchor:)" do
+      let(:notation) { "V4L6M" }
+
+      context "when the completions currently satisfy the cycle" do
+        let(:completed_dates) do
+          [
+            anchor - 1.day,
+            anchor - 5.months,
+            anchor - 5.months,
+            anchor - 5.months,
+            anchor - 5.months,
+            anchor - 1.year
+          ]
+        end
+
+        it "returns the volume needed to delay expiration" do
+          expect(cycle.volume_to_delay_expiration(completed_dates, anchor:)).to eq(3)
+        end
+
+        context "when the considered dates are < the covered_dates" do
+          let(:completed_dates) do
+            [
+              anchor - 1.day,
+              anchor - 3.months,
+              anchor - 3.months,
+              anchor - 3.months,
+              anchor - 5.months,
+              anchor - 5.months,
+              anchor - 1.year
+            ]
+          end
+
+          it "returns the volume needed to delay expiration" do
+            # The expiration only considers the `anchor - 3.months` and more recent
+            # completions, so how many new completions are needed to result in
+            # a more recent oldest-of-considered-datex?
+            expect(cycle.volume_to_delay_expiration(completed_dates, anchor:)).to eq(3)
+          end
+        end
+      end
+
+      context "when the completions currently do not satisfy the cycle" do
+        let(:completed_dates) { Array.new(6, anchor - 1.year) }
+
+        it "returns nil" do
+          expect(cycle.volume_to_delay_expiration(completed_dates, anchor:)).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/sof/cycles/lookback_spec.rb
+++ b/spec/sof/cycles/lookback_spec.rb
@@ -51,6 +51,28 @@ module SOF
       end
     end
 
+    describe "#considered_dates" do
+      let(:completed_dates) do
+        [
+          recent_date,
+          middle_date,
+          middle_date,
+          early_date,
+          early_date,
+          out_of_window_date
+        ]
+      end
+      let(:notation) { "V3L180D" }
+
+      it "returns {volume} most recent of the #covered_dates" do
+        expect(cycle.considered_dates(completed_dates, anchor:)).to eq([
+          recent_date,
+          middle_date,
+          middle_date
+        ])
+      end
+    end
+
     describe "#satisfied_by?(completed_dates, anchor:)" do
       context "when the completions--judged from the anchor--satisfy the cycle" do
         it "returns true" do


### PR DESCRIPTION
We had a subtle bug for `Cycles::Lookback#volume_to_delay_expiration`. 

Consider a cycle with `V3L6M` and completions:
```ruby
[  
  recent_date
  middle_date
  middle_date
  old_but_still_covered_date
]
```

We had been returning `1`, because a new completion would displace `old_but_still_covered_date`, but that one was already ignored in computation of `expires_after` because it was the 4th oldest completion and we only need 3. 

We now return `2`, correctly revealing that 2 new completions are needed to delay the current `expires_after`