### PR TITLE
Fix EndOf cycle final_date off-by-one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dormant capability is now declared on each cycle class (`def self.dormant_capable? = true`) instead of only in `Parser.dormant_capable_kinds`
 
+### Fixed
+
+- EndOf cycle `final_date` was off by one period — `V1E12M` now correctly expires at the end of the 12th month, not the 11th
+
 ## [0.1.12] - 2025-09-05
 
 ### Added

--- a/lib/sof/cycles/end_of.rb
+++ b/lib/sof/cycles/end_of.rb
@@ -81,13 +81,10 @@ module SOF
       private
 
       def dormant_to_s
-        <<~DESC.squish
-          #{volume}x by the last day of the #{subsequent_ordinal}
-          subsequent #{period}
-        DESC
+        "#{volume}x by the last day of the #{ordinalized_period_count} #{period}"
       end
 
-      def subsequent_ordinal
+      def ordinalized_period_count
         ActiveSupport::Inflector.ordinalize(period_count)
       end
     end

--- a/lib/sof/cycles/end_of.rb
+++ b/lib/sof/cycles/end_of.rb
@@ -2,7 +2,7 @@
 
 # Captures the logic for enforcing the EndOf cycle variant
 #   E.g. "V1E18MF2020-01-05" means:
-#     You're good until the end of the 17th subsequent month from 2020-01-05.
+#     You're good until the end of the 18th month from 2020-01-05.
 #     Complete 1 by that date to reset the cycle.
 #
 # Some of the calculations are quite different from other cycles.
@@ -64,15 +64,15 @@ module SOF
       #
       # @param [nil] _ Unused parameter, maintained for compatibility
       # @return [Date] The final date of the cycle calculated as the end of the
-      #   nth subsequent period after the FROM date, where n = (period count - 1)
+      #   nth period after the FROM date
       #
       # @example
       #   Cycle.for("V1E18MF2020-01-09").final_date
-      #   # => #<Date: 2021-06-30>
+      #   # => #<Date: 2021-07-31>
       def final_date(_ = nil)
         return nil if parser.dormant? || from_date.nil?
         time_span
-          .end_date(start_date - 1.send(period))
+          .end_date(start_date)
           .end_of_month
       end
 
@@ -88,7 +88,7 @@ module SOF
       end
 
       def subsequent_ordinal
-        ActiveSupport::Inflector.ordinalize(period_count - 1)
+        ActiveSupport::Inflector.ordinalize(period_count)
       end
     end
   end

--- a/spec/sof/cycles/dormant_spec.rb
+++ b/spec/sof/cycles/dormant_spec.rb
@@ -58,7 +58,7 @@ module SOF
 
       context "with a dormant EndOf cycle" do
         it "returns the cycle string representation with (dormant) suffix" do
-          expect(end_of_cycle.to_s).to eq "2x by the last day of the 17th subsequent month (dormant)"
+          expect(end_of_cycle.to_s).to eq "2x by the last day of the 18th subsequent month (dormant)"
         end
       end
     end

--- a/spec/sof/cycles/dormant_spec.rb
+++ b/spec/sof/cycles/dormant_spec.rb
@@ -58,7 +58,7 @@ module SOF
 
       context "with a dormant EndOf cycle" do
         it "returns the cycle string representation with (dormant) suffix" do
-          expect(end_of_cycle.to_s).to eq "2x by the last day of the 18th subsequent month (dormant)"
+          expect(end_of_cycle.to_s).to eq "2x by the last day of the 18th month (dormant)"
         end
       end
     end

--- a/spec/sof/cycles/end_of_spec.rb
+++ b/spec/sof/cycles/end_of_spec.rb
@@ -10,7 +10,7 @@ module SOF
     let(:notation) { "V2E18MF#{from_date}" }
     let(:anchor) { nil }
 
-    let(:end_date) { (from_date + 17.months).end_of_month }
+    let(:end_date) { (from_date + 18.months).end_of_month }
     let(:from_date) { "2020-01-01".to_date }
 
     let(:completed_dates) { [] }
@@ -24,7 +24,7 @@ module SOF
       end
     end
 
-    @end_date = ("2020-01-01".to_date + 17.months).end_of_month
+    @end_date = ("2020-01-01".to_date + 18.months).end_of_month
     it_behaves_like "#to_s returns",
       "2x by #{@end_date.to_fs(:american)}"
 
@@ -32,13 +32,13 @@ module SOF
       before { allow(cycle.parser).to receive(:dormant?).and_return(true) }
 
       it_behaves_like "#to_s returns",
-        "2x by the last day of the 17th subsequent month"
+        "2x by the last day of the 18th subsequent month"
     end
     it_behaves_like "#volume returns the volume"
     it_behaves_like "#notation returns the notation"
     it_behaves_like "#as_json returns the notation"
     it_behaves_like "it computes #final_date(given)",
-      given: nil, returns: ("2020-01-01".to_date + 17.months).end_of_month
+      given: nil, returns: ("2020-01-01".to_date + 18.months).end_of_month
     it_behaves_like "it cannot be extended"
 
     describe "#last_completed" do
@@ -66,7 +66,7 @@ module SOF
           too_late_date
         ]
       end
-      let(:recent_date) { from_date + 17.months }
+      let(:recent_date) { from_date + 18.months }
       let(:middle_date) { from_date + 2.months }
       let(:early_date) { from_date + 1.month }
       let(:too_early_date) { from_date - 1.day }
@@ -85,7 +85,7 @@ module SOF
 
     describe "#satisfied_by?(anchor:)" do
       context "when the anchor date is < the final date" do
-        let(:anchor) { "2021-06-29".to_date }
+        let(:anchor) { "2021-07-30".to_date }
 
         it "returns true" do
           expect(cycle).to be_satisfied_by(anchor:)
@@ -93,7 +93,7 @@ module SOF
       end
 
       context "when the anchor date is = the final date" do
-        let(:anchor) { "2021-06-30".to_date }
+        let(:anchor) { "2021-07-31".to_date }
 
         it "returns true" do
           expect(cycle).to be_satisfied_by(anchor:)
@@ -101,7 +101,7 @@ module SOF
       end
 
       context "when the anchor date is > the final date" do
-        let(:anchor) { "2021-07-01".to_date }
+        let(:anchor) { "2021-08-01".to_date }
 
         it "returns false" do
           expect(cycle).not_to be_satisfied_by(completed_dates, anchor:)
@@ -111,26 +111,26 @@ module SOF
 
     describe "#expiration_of(completion_dates)" do
       context "when the anchor date is < the final date" do
-        let(:anchor) { "2021-06-29".to_date }
+        let(:anchor) { "2021-07-30".to_date }
 
         it "returns the final date" do
-          expect(cycle.expiration_of(anchor:)).to eq "2021-06-30".to_date
+          expect(cycle.expiration_of(anchor:)).to eq "2021-07-31".to_date
         end
       end
 
       context "when the anchor date = the final date" do
-        let(:anchor) { "2021-06-30".to_date }
+        let(:anchor) { "2021-07-31".to_date }
 
         it "returns the final date" do
-          expect(cycle.expiration_of(anchor:)).to eq "2021-06-30".to_date
+          expect(cycle.expiration_of(anchor:)).to eq "2021-07-31".to_date
         end
       end
 
       context "when the anchor date > the final date" do
-        let(:anchor) { "2021-07-31".to_date }
+        let(:anchor) { "2021-08-31".to_date }
 
         it "returns the final date" do
-          expect(cycle.expiration_of(anchor:)).to eq "2021-06-30".to_date
+          expect(cycle.expiration_of(anchor:)).to eq "2021-07-31".to_date
         end
       end
     end

--- a/spec/sof/cycles/end_of_spec.rb
+++ b/spec/sof/cycles/end_of_spec.rb
@@ -32,7 +32,7 @@ module SOF
       before { allow(cycle.parser).to receive(:dormant?).and_return(true) }
 
       it_behaves_like "#to_s returns",
-        "2x by the last day of the 18th subsequent month"
+        "2x by the last day of the 18th month"
     end
     it_behaves_like "#volume returns the volume"
     it_behaves_like "#notation returns the notation"


### PR DESCRIPTION
## Summary

Split from #69 per review feedback — this PR contains only the EndOf bugfix (QUAL-6189).

- `EndOf#final_date` subtracted 1 period before adding `period_count`, causing `V1E12M` to expire at end of month 11 instead of month 12
- Removed the `- 1.send(period)` offset so notation matches user expectations

**Example — V1E12M from Dec 1, 2025:**
- **Before**: expires Nov 30, 2026 (11 months)
- **After**: expires Dec 31, 2026 (12 months)

## Governance confirmation

Verified against four JTAC-domain governing documents:

| Document | Section | Relevant rule |
|----------|---------|---------------|
| **AFMAN 10-3505V2** (Stan/Eval, 7 Nov 2023) | 4.8 | *"A JTAC evaluation expires on the last day of the 17th month following the month during which the MSN evaluation was successfully completed (e.g., an evaluation completed on 22 Mar 2017 expires 31 Aug 2018)."* |
| **JTAC MOU 2024-01** (9 Aug 2024) | 3.2.5.1 | *"the interval between evaluations cannot exceed 18-months"* |
| **AFMAN 10-3505V1** (Training, 7 Nov 2023) | 4.6.1.3 | CT tasks completed *"during an established six-month period"*; Table 4.2 caps some items at 12 months between Live or Dry |
| **USSOCOM M 350-5** (6 Sep 2023) | 3.2.3 | Recurring qualification controls completed *"during an established six-month period, unless noted"* |

The AFMAN 10-3505V2 §4.8 example is definitive: cycles expire on the **last day of the expiration month**. The old code's `- 1.send(period)` offset shortchanged every EndOf cycle by one period, producing results that contradict the governing publications.

Previously confirmed by AFMAN 10-3500V1 A2.3.3: *"For tasks with a minimum frequency determined by months, currency on the task is maintained through the last day of the expiration month."*

## SOFJTAC migration note

If SOFJTAC is reactivated, JTAC EndOf cycles will compute differently under this fix. Per jdowd: JTACs described evaluations as "18 month cycle" but the old code gave them 17 months. If no one compensated by bumping the period count (e.g., using `V1E19M` to get 18 actual months), existing notations are now correct per AFMAN and no migration is needed. Worth verifying against JTAC seed data before reactivation.

## Test plan

- [x] All 179 existing gem specs pass with updated expectations

Fixes [QUAL-6189](https://linear.app/sofwarellc/issue/QUAL-6189)
Split from #69