### PR TITLE
Move dormant_capable? from Parser to cycle classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.13] - Unreleased
 
+### Changed
+
+- Dormant capability is now declared on each cycle class (`def self.dormant_capable? = true`) instead of only in `Parser.dormant_capable_kinds`
+
 ## [0.1.12] - 2025-09-05
 
 ### Added

--- a/lib/sof/cycle.rb
+++ b/lib/sof/cycle.rb
@@ -130,6 +130,8 @@ module SOF
       attr_reader :notation_id, :kind, :valid_periods
       def volume_only? = @volume_only
 
+      def dormant_capable? = false
+
       def recurring? = raise "#{name} must implement #{__method__}"
 
       # Raises an error if the given period isn't in the list of valid periods.

--- a/lib/sof/cycles/end_of.rb
+++ b/lib/sof/cycles/end_of.rb
@@ -18,6 +18,8 @@ module SOF
 
       def self.recurring? = true
 
+      def self.dormant_capable? = true
+
       def self.description
         "End of - occurrences by the end of a time period"
       end

--- a/lib/sof/cycles/within.rb
+++ b/lib/sof/cycles/within.rb
@@ -10,6 +10,8 @@ module SOF
 
       def self.recurring? = false
 
+      def self.dormant_capable? = true
+
       def self.description
         "Within - occurrences within a time period from a specific date"
       end

--- a/lib/sof/parser.rb
+++ b/lib/sof/parser.rb
@@ -20,7 +20,9 @@ module SOF
       (?<from>F(?<from_date>\d{4}-\d{2}-\d{2}))?$ # optional from
     /ix
 
-    def self.dormant_capable_kinds = %w[E W]
+    def self.dormant_capable_kinds
+      Cycle.cycle_handlers.select(&:dormant_capable?).map(&:notation_id).compact
+    end
 
     def self.for(notation_or_parser)
       return notation_or_parser if notation_or_parser.is_a? self


### PR DESCRIPTION
## Summary

Addresses jdowd's feedback from #69:

> "I don't love that the dormant-capability is only revealed in Parser, but we should have a single pattern for this"

Each cycle class now declares its own dormant capability alongside `recurring?`:

```ruby
def self.recurring? = true
def self.dormant_capable? = true   # EndOf, Within
```

`Parser.dormant_capable_kinds` now derives the list from the cycle classes instead of a hardcoded array. Adding a new dormant-capable cycle kind only requires declaring `dormant_capable?` on the class — no separate Parser edit needed.

### Before

To make a cycle dormant-capable, you had to:
1. Add behavior to the cycle class
2. **Also** add its notation letter to `Parser.dormant_capable_kinds = %w[E W]`

### After

Just declare it on the class:
```ruby
def self.dormant_capable? = true
```

## Test plan

- [x] All 179 existing specs pass (no new specs needed — pure refactor)
- [x] StandardRB clean

No behavior change — this is a mechanical refactor that makes cycle classes self-describing.