### PR TITLE
sof-cycle: Rename Cycle#expiration_of to #expires_after

### DIFF
--- a/lib/sof/cycle.rb
+++ b/lib/sof/cycle.rb
@@ -13,6 +13,8 @@ module SOF
 
     class InvalidKind < InvalidInput; end
 
+    Deprecation = ActiveSupport::Deprecation.new("0.2.0", "sof-cycle")
+
     class << self
       # Turn a cycle or notation string into a hash
       def dump(cycle_or_string)
@@ -282,7 +284,21 @@ module SOF
     # Return the final date of the cycle
     def final_date(_anchor) = nil
 
-    def expiration_of(_completion_dates, anchor: Date.current) = nil
+    # The last date on which the supplied completions still satisfy the cycle.
+    # The cycle goes red the day *after* this date.
+    #
+    # @return [Date, nil] the final satisfied date, or nil if already unsatisfied
+    def expires_after(_completion_dates, anchor: Date.current) = nil
+
+    # @deprecated Use {#expires_after} instead. The name implied the first
+    #   unsatisfied date, but the value returned is the last *satisfied* date.
+    def expiration_of(...)
+      Deprecation.warn(
+        "SOF::Cycle#expiration_of is deprecated and will be removed in 0.2.0; " \
+        "use #expires_after instead."
+      )
+      expires_after(...)
+    end
 
     def volume_to_delay_expiration(_completion_dates, anchor:) = 0
 

--- a/lib/sof/cycles/calendar.rb
+++ b/lib/sof/cycles/calendar.rb
@@ -26,10 +26,11 @@ module SOF
         "#{volume}x every #{period_count} calendar #{humanized_period}"
       end
 
-      # "Absent further completions, you go red on this date"
-      # @return [Date, nil] the date on which the cycle will expire given the
-      #   provided completion dates. Returns nil if the cycle is already unsatisfied.
-      def expiration_of(completion_dates)
+      # The last date the completions still satisfy the cycle; absent further
+      # completions, the cycle goes red after this date.
+      # @return [Date, nil] the final satisfied date given the provided
+      #   completion dates. Returns nil if the cycle is already unsatisfied.
+      def expires_after(completion_dates)
         anchor = completion_dates.max_by(volume) { it }.min
         return unless satisfied_by?(completion_dates, anchor:)
 

--- a/lib/sof/cycles/dormant.rb
+++ b/lib/sof/cycles/dormant.rb
@@ -22,7 +22,7 @@ module SOF
 
       def covered_dates(...) = []
 
-      def expiration_of(...) = nil
+      def expires_after(...) = nil
 
       def satisfied_by?(...) = false
 

--- a/lib/sof/cycles/end_of.rb
+++ b/lib/sof/cycles/end_of.rb
@@ -45,9 +45,9 @@ module SOF
       #
       # @example
       #   Cycle.for("V1E18MF2020-01-09")
-      #     .expiration_of(anchor: "2020-06-04".to_date)
+      #     .expires_after(anchor: "2020-06-04".to_date)
       #   # => #<Date: 2021-06-30>
-      def expiration_of(_ = nil, anchor: nil)
+      def expires_after(_ = nil, anchor: nil)
         return nil if parser.dormant? || from_date.nil?
         final_date
       end

--- a/lib/sof/cycles/interval.rb
+++ b/lib/sof/cycles/interval.rb
@@ -37,7 +37,7 @@ module SOF
       # Returns the expiration date for the current window
       #
       # @return [Date, nil] The final date of the current window
-      def expiration_of(_ = nil, anchor: nil)
+      def expires_after(_ = nil, anchor: nil)
         final_date
       end
 

--- a/lib/sof/cycles/lookback.rb
+++ b/lib/sof/cycles/lookback.rb
@@ -29,10 +29,11 @@ module SOF
         relevant_dates.count(relevant_dates.min)
       end
 
-      # "Absent further completions, you go red on this date"
-      # @return [Date, nil] the date on which the cycle will expire given the
-      #   provided completion dates. Returns nil if the cycle is already unsatisfied.
-      def expiration_of(completion_dates)
+      # The last date the completions still satisfy the cycle; absent further
+      # completions, you go red the day *after* this date.
+      # @return [Date, nil] the final satisfied date given the provided
+      #   completion dates. Returns nil if the cycle is already unsatisfied.
+      def expires_after(completion_dates)
         anchor = completion_dates.max_by(volume) { it }.min
         return unless satisfied_by?(completion_dates, anchor:)
 

--- a/lib/sof/cycles/lookback_end_of.rb
+++ b/lib/sof/cycles/lookback_end_of.rb
@@ -20,7 +20,7 @@ module SOF
 
       def to_s = "#{volume}x in the prior #{period_count} #{humanized_period} (end of period)"
 
-      def expiration_of(completion_dates, anchor: Date.current)
+      def expires_after(completion_dates, anchor: Date.current)
         oldest = completion_dates.max_by(volume) { it }.min
         return unless satisfied_by?(completion_dates, anchor:)
 

--- a/spec/sof/cycles/calendar_spec.rb
+++ b/spec/sof/cycles/calendar_spec.rb
@@ -81,10 +81,10 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates)" do
+    describe "#expires_after(completion_dates)" do
       context "when the completions currently satisfy the cycle" do
         it "returns the end of the _next_ calendar period" do
-          expect(cycle.expiration_of(completed_dates)).to eq(
+          expect(cycle.expires_after(completed_dates)).to eq(
             (recent_date + 1.year).end_of_year
           )
         end
@@ -96,7 +96,7 @@ module SOF
         let(:anchor) { "2020-01-16".to_date }
 
         it "returns the end of the _next_ calendar period" do
-          expect(cycle.expiration_of(completed_dates)).to eq(
+          expect(cycle.expires_after(completed_dates)).to eq(
             "2020-02-29".to_date
           )
         end
@@ -106,7 +106,7 @@ module SOF
         let(:notation) { "V5L180D" }
 
         it "returns nil" do
-          expect(cycle.expiration_of(completed_dates)).to be_nil
+          expect(cycle.expires_after(completed_dates)).to be_nil
         end
       end
     end

--- a/spec/sof/cycles/dormant_spec.rb
+++ b/spec/sof/cycles/dormant_spec.rb
@@ -135,17 +135,17 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates)" do
+    describe "#expires_after(completion_dates)" do
       it "always returns nil" do
         aggregate_failures do
-          expect(within_cycle.expiration_of(completed_dates)).to be_nil
-          expect(within_cycle.expiration_of([])).to be_nil
+          expect(within_cycle.expires_after(completed_dates)).to be_nil
+          expect(within_cycle.expires_after([])).to be_nil
 
-          expect(end_of_cycle.expiration_of(completed_dates)).to be_nil
-          expect(end_of_cycle.expiration_of([])).to be_nil
+          expect(end_of_cycle.expires_after(completed_dates)).to be_nil
+          expect(end_of_cycle.expires_after([])).to be_nil
 
-          expect(interval_cycle.expiration_of(completed_dates)).to be_nil
-          expect(interval_cycle.expiration_of([])).to be_nil
+          expect(interval_cycle.expires_after(completed_dates)).to be_nil
+          expect(interval_cycle.expires_after([])).to be_nil
         end
       end
     end

--- a/spec/sof/cycles/end_of_spec.rb
+++ b/spec/sof/cycles/end_of_spec.rb
@@ -109,12 +109,12 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates)" do
+    describe "#expires_after(completion_dates)" do
       context "when the anchor date is < the final date" do
         let(:anchor) { "2021-07-30".to_date }
 
         it "returns the final date" do
-          expect(cycle.expiration_of(anchor:)).to eq "2021-07-31".to_date
+          expect(cycle.expires_after(anchor:)).to eq "2021-07-31".to_date
         end
       end
 
@@ -122,7 +122,7 @@ module SOF
         let(:anchor) { "2021-07-31".to_date }
 
         it "returns the final date" do
-          expect(cycle.expiration_of(anchor:)).to eq "2021-07-31".to_date
+          expect(cycle.expires_after(anchor:)).to eq "2021-07-31".to_date
         end
       end
 
@@ -130,7 +130,7 @@ module SOF
         let(:anchor) { "2021-08-31".to_date }
 
         it "returns the final date" do
-          expect(cycle.expiration_of(anchor:)).to eq "2021-07-31".to_date
+          expect(cycle.expires_after(anchor:)).to eq "2021-07-31".to_date
         end
       end
     end

--- a/spec/sof/cycles/interval_spec.rb
+++ b/spec/sof/cycles/interval_spec.rb
@@ -134,9 +134,9 @@ module SOF
       end
     end
 
-    describe "#expiration_of" do
+    describe "#expires_after" do
       it "returns the final date" do
-        expect(cycle.expiration_of).to eq "2028-03-31".to_date
+        expect(cycle.expires_after).to eq "2028-03-31".to_date
       end
     end
 
@@ -151,8 +151,8 @@ module SOF
         expect(cycle.final_date).to be_nil
       end
 
-      it "returns nil for expiration_of" do
-        expect(cycle.expiration_of).to be_nil
+      it "returns nil for expires_after" do
+        expect(cycle.expires_after).to be_nil
       end
 
       it "returns false for satisfied_by?" do

--- a/spec/sof/cycles/lookback_end_of_spec.rb
+++ b/spec/sof/cycles/lookback_end_of_spec.rb
@@ -74,25 +74,25 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates, anchor:)" do
+    describe "#expires_after(completion_dates, anchor:)" do
       context "when satisfied" do
         # The expiration is computed from the completion, not the anchor:
         # April 9, 2024 + 24 months = April 9, 2026 → end_of_month = April 30, 2026
         it "returns the end of the period in which the window boundary falls" do
-          expect(cycle.expiration_of([edge_completion], anchor:)).to eq("2026-04-30".to_date)
+          expect(cycle.expires_after([edge_completion], anchor:)).to eq("2026-04-30".to_date)
         end
       end
 
       context "with a completion in the middle of a period" do
         # May 15, 2024 + 24 months = May 15, 2026 → end_of_month = May 31, 2026
         it "rounds to end of that period" do
-          expect(cycle.expiration_of([inside_completion], anchor:)).to eq("2026-05-31".to_date)
+          expect(cycle.expires_after([inside_completion], anchor:)).to eq("2026-05-31".to_date)
         end
       end
 
       context "when not satisfied" do
         it "returns nil" do
-          expect(cycle.expiration_of([outside_completion], anchor:)).to be_nil
+          expect(cycle.expires_after([outside_completion], anchor:)).to be_nil
         end
       end
 
@@ -102,7 +102,7 @@ module SOF
         # Uses the oldest of the most recent 2 completions to anchor the window:
         # edge_completion (April 9, 2024) is the older of the two → April 9, 2024 + 24 months = April 30, 2026
         it "uses the oldest of the most recent volume completions" do
-          expect(cycle.expiration_of([inside_completion, edge_completion], anchor:)).to eq("2026-04-30".to_date)
+          expect(cycle.expires_after([inside_completion, edge_completion], anchor:)).to eq("2026-04-30".to_date)
         end
       end
     end

--- a/spec/sof/cycles/lookback_spec.rb
+++ b/spec/sof/cycles/lookback_spec.rb
@@ -103,10 +103,10 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates)" do
+    describe "#expires_after(completion_dates)" do
       context "when the completions currently satisfy the cycle" do
-        it "returns the date on which the completions will no longer satisfy the cycle" do
-          expect(cycle.expiration_of(completed_dates)).to eq(middle_date + 180.days)
+        it "returns the last date the completions still satisfy the cycle" do
+          expect(cycle.expires_after(completed_dates)).to eq(middle_date + 180.days)
         end
       end
 
@@ -114,8 +114,15 @@ module SOF
         let(:notation) { "V5L180D" }
 
         it "returns nil" do
-          expect(cycle.expiration_of(completed_dates)).to be_nil
+          expect(cycle.expires_after(completed_dates)).to be_nil
         end
+      end
+    end
+
+    describe "#expiration_of (deprecated alias)" do
+      it "delegates to #expires_after and emits a deprecation warning" do
+        expect(SOF::Cycle::Deprecation).to receive(:warn).with(/expires_after/)
+        expect(cycle.expiration_of(completed_dates)).to eq(cycle.expires_after(completed_dates))
       end
     end
 

--- a/spec/sof/cycles/volume_only_spec.rb
+++ b/spec/sof/cycles/volume_only_spec.rb
@@ -85,10 +85,10 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates)" do
+    describe "#expires_after(completion_dates)" do
       context "when the completions currently satisfy the cycle" do
         it "returns nil" do
-          expect(cycle.expiration_of(completed_dates)).to be nil
+          expect(cycle.expires_after(completed_dates)).to be nil
         end
       end
 
@@ -96,7 +96,7 @@ module SOF
         let(:notation) { "V5L180D" }
 
         it "returns nil" do
-          expect(cycle.expiration_of(completed_dates)).to be_nil
+          expect(cycle.expires_after(completed_dates)).to be_nil
         end
       end
     end

--- a/spec/sof/cycles/within_spec.rb
+++ b/spec/sof/cycles/within_spec.rb
@@ -97,10 +97,10 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates)" do
+    describe "#expires_after(completion_dates)" do
       context "when the completions currently satisfy the cycle" do
         it "returns nil" do
-          expect(cycle.expiration_of(completed_dates)).to be nil
+          expect(cycle.expires_after(completed_dates)).to be nil
         end
       end
 
@@ -108,7 +108,7 @@ module SOF
         let(:notation) { "V5L180D" }
 
         it "returns nil" do
-          expect(cycle.expiration_of(completed_dates)).to be_nil
+          expect(cycle.expires_after(completed_dates)).to be_nil
         end
       end
     end


### PR DESCRIPTION
> **Stacked on #83** (the LookbackEndOf anchor fix). Review/merge #83 first; this PR's base will auto-retarget to `main` once #83 lands. The diff here is the rename only.

## Why

`Cycle#expiration_of` is named misleadingly. The name implies the first *unsatisfied* date (when the cycle goes red), but it returns the **last date the completions still satisfy** the cycle — it goes red the day *after*.

For a lookback `V2L180D` with the 2nd-most-recent completion on `middle`, it returns `middle + 180`. On that date the window `[middle, middle+180]` still includes `middle` (satisfied); it only drops the next day. The doc comments (`"...you go red on this date"`) and a spec description reinforced the wrong reading.

## What

- Rename `#expiration_of` → `#expires_after` across the `Cycle` hierarchy (base + `Lookback`, `LookbackEndOf`, `Calendar`, `EndOf`, `Interval`, `Dormant`).
- Keep `#expiration_of` as a **deprecating delegate** (removal targeted 0.2.0) so downstream consumers (Qualify, SOFJTAC) have a migration window. It forwards via `(...)` to preserve polymorphic dispatch — a bare `alias_method` would bind to the base impl and break dispatch. Wires up the already-required-but-unused `active_support/deprecation`.
- Corrected the misleading doc comments and imprecise spec wording.

## Testing

Full suite green — **229 examples, 0 failures** (on top of the #83 base).

## Follow-up

- Bump consumers to a release with `#expires_after` and migrate call sites before the 0.2.0 removal.

Resolves QUAL-6822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)