### PR TITLE
sof-cycle: Pin anchor in LookbackEndOf specs (fix time-dependent failures)

### DIFF
--- a/spec/sof/cycles/lookback_end_of_spec.rb
+++ b/spec/sof/cycles/lookback_end_of_spec.rb
@@ -74,35 +74,35 @@ module SOF
       end
     end
 
-    describe "#expiration_of(completion_dates)" do
+    describe "#expiration_of(completion_dates, anchor:)" do
       context "when satisfied" do
-        # anchor = edge_completion = April 9, 2024
+        # The expiration is computed from the completion, not the anchor:
         # April 9, 2024 + 24 months = April 9, 2026 → end_of_month = April 30, 2026
         it "returns the end of the period in which the window boundary falls" do
-          expect(cycle.expiration_of([edge_completion])).to eq("2026-04-30".to_date)
+          expect(cycle.expiration_of([edge_completion], anchor:)).to eq("2026-04-30".to_date)
         end
       end
 
       context "with a completion in the middle of a period" do
         # May 15, 2024 + 24 months = May 15, 2026 → end_of_month = May 31, 2026
         it "rounds to end of that period" do
-          expect(cycle.expiration_of([inside_completion])).to eq("2026-05-31".to_date)
+          expect(cycle.expiration_of([inside_completion], anchor:)).to eq("2026-05-31".to_date)
         end
       end
 
       context "when not satisfied" do
         it "returns nil" do
-          expect(cycle.expiration_of([outside_completion])).to be_nil
+          expect(cycle.expiration_of([outside_completion], anchor:)).to be_nil
         end
       end
 
       context "with volume > 1" do
         let(:notation) { "V2LE24M" }
 
-        # Uses the oldest of the most recent 2 completions as the anchor.
+        # Uses the oldest of the most recent 2 completions to anchor the window:
         # edge_completion (April 9, 2024) is the older of the two → April 9, 2024 + 24 months = April 30, 2026
         it "uses the oldest of the most recent volume completions" do
-          expect(cycle.expiration_of([inside_completion, edge_completion])).to eq("2026-04-30".to_date)
+          expect(cycle.expiration_of([inside_completion, edge_completion], anchor:)).to eq("2026-04-30".to_date)
         end
       end
     end


### PR DESCRIPTION
## Why

Three examples in `lookback_end_of_spec.rb` call `#expiration_of` **without** an `anchor`, defaulting to `Date.current`. The fixtures are absolute 2024 dates against a hardcoded `anchor` of 2026-04-10. While `Date.current` stayed in April 2026 the default path happened to land inside the 24-month window, so they passed.

Added 2026-04-10 (`273ab84`); CI last ran on `main` 2026-04-27 — before the edge. On **2026-05-01** `beginning_of_month(Date.current − 24mo)` rolled past `edge_completion` and the examples began returning `nil`. **They are red on `main` today.**

## What

Pin `anchor:` (the existing `2026-04-10` let) on the four `#expiration_of` calls, matching every other block in the file. The returned expiration derives from the completion date, not the anchor, so expectations are unchanged — this only stops `satisfied_by?` from being judged against a drifting "today". Also fixes a comment that conflated the satisfaction anchor with the completion date.

Test-only change; no library behavior affected.

## Testing

`lookback_end_of_spec` green (20 examples, 0 failures) and now deterministic regardless of the current date.

## Notes

- The rename of `#expiration_of` → `#expires_after` (#82) stacks on top of this.
- Follow-up worth its own ticket: no time-freezing exists in the suite, so any `Date.current`-dependent spec is implicitly date-dependent. A global frozen "now" would prevent this class of bug.

Resolves QUAL-6823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)