### PR TITLE
Reset recurring cycles from the act that satisfies them

### DIFF
--- a/lib/sof/cycle.rb
+++ b/lib/sof/cycle.rb
@@ -253,6 +253,39 @@ module SOF
 
     def extend_period(_ = nil) = self
 
+    # Whether this kind of cycle can be written without a from date, and so
+    # can be anchored later. Answers on the instance so a dormant cycle can
+    # be asked too — `cycle.class` is Cycles::Dormant there, which knows
+    # nothing of the kind it wraps.
+    def dormant_capable? = self.class.dormant_capable?
+
+    # The cycle restarted from the latest of `dates` past its current anchor.
+    #
+    # A recurring, dormant-capable window (E and I) is reset by the act that
+    # satisfies it — "complete 1 by that date to reset the cycle". Nothing in
+    # the notation does that on its own, so this used to fall to each
+    # consuming app.
+    #
+    # Dates on or before the current anchor are ignored: a back-dated act
+    # must not drag a forward-running window backwards. Every other kind
+    # returns itself — a lookback window already slides, a calendar window is
+    # pinned to the calendar, a one-shot window does not repeat, and an
+    # un-anchored one has no window to move until it is activated.
+    #
+    # @param dates [Array<Date, Time, nil>] the acts that satisfy this cycle
+    # @return [Cycle] the reset cycle, or self when nothing resets it
+    #
+    # @example
+    #   Cycle.for("V1E18MF2026-02-01").reset_by([Date.new(2026, 9, 15)])
+    #   # => Cycle.for("V1E18MF2026-09-15")
+    def reset_by(dates)
+      return self unless recurring? && dormant_capable?
+      return self if from_date.nil?
+
+      reset = reset_date(dates)
+      reset ? Cycle.for(activated_notation(reset)) : self
+    end
+
     # From the supplied anchor date, are there enough in-window completions to
     # satisfy the cycle?
     #
@@ -303,5 +336,13 @@ module SOF
     end
 
     def as_json(...) = notation
+
+    private
+
+    # The latest date that moves this cycle's window forward, or nil.
+    def reset_date(dates)
+      anchored_on = from_date.to_date
+      Array(dates).filter_map { it&.to_date }.select { it > anchored_on }.max
+    end
   end
 end

--- a/lib/sof/cycles/dormant.rb
+++ b/lib/sof/cycles/dormant.rb
@@ -22,6 +22,10 @@ module SOF
 
       def covered_dates(...) = []
 
+      # No anchor yet, so nothing to move: a dormant cycle is reset by being
+      # activated, not by the acts that satisfy it.
+      def reset_by(...) = self
+
       def expiration_of(...) = nil
 
       def satisfied_by?(...) = false

--- a/spec/sof/cycle_reset_spec.rb
+++ b/spec/sof/cycle_reset_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module SOF
+  # A recurring, dormant-capable window (E and I) restarts from the act that
+  # satisfies it. Previously every consuming app had to do this itself.
+  RSpec.describe Cycle, "#reset_by", type: :value do
+    describe "an EndOf cycle" do
+      subject(:cycle) { Cycle.for("V1E18MF2026-02-01") }
+
+      it "re-anchors from the latest date past its anchor" do
+        reset = cycle.reset_by([Date.new(2026, 6, 1), Date.new(2026, 9, 15)])
+
+        expect(reset.notation).to eq("V1E18MF2026-09-15")
+        expect(reset.final_date).to eq(Date.new(2028, 3, 31))
+      end
+
+      it "returns itself when no date resets it" do
+        expect(cycle.reset_by([])).to eq(cycle)
+      end
+
+      it "ignores dates on or before the anchor so the window never moves backwards" do
+        reset = cycle.reset_by([Date.new(2025, 12, 1), Date.new(2026, 2, 1)])
+
+        expect(reset.notation).to eq("V1E18MF2026-02-01")
+      end
+
+      it "re-anchors from a date past the window, restoring a lapsed cycle" do
+        reset = cycle.reset_by([Date.new(2029, 1, 1)])
+
+        expect(reset).to be_satisfied_by([], anchor: Date.new(2029, 6, 1))
+      end
+
+      it "accepts times and nils among the dates" do
+        reset = cycle.reset_by([nil, Time.parse("2026-06-01 13:45")])
+
+        expect(reset.notation).to eq("V1E18MF2026-06-01")
+      end
+    end
+
+    describe "an Interval cycle" do
+      subject(:cycle) { Cycle.for("V1I24MF2026-03-31") }
+
+      it "re-anchors from the completion date, as its notation promises" do
+        reset = cycle.reset_by([Date.new(2027, 1, 10)])
+
+        expect(reset.notation).to eq("V1I24MF2027-01-10")
+        expect(reset.final_date).to eq(Date.new(2029, 1, 10))
+      end
+    end
+
+    describe "cycles that do not reset" do
+      it "leaves a dormant cycle alone — it has no anchor to move" do
+        cycle = Cycle.for("V1E18M")
+
+        expect(cycle.reset_by([Date.new(2026, 6, 1)])).to eq(cycle)
+        expect(cycle).to be_dormant
+      end
+
+      it "leaves a Lookback alone — its window already slides" do
+        cycle = Cycle.for("V1L180D")
+
+        expect(cycle.reset_by([Date.new(2026, 6, 1)]).notation).to eq("V1L180D")
+      end
+
+      it "leaves a LookbackEndOf alone" do
+        cycle = Cycle.for("V1LE6M")
+
+        expect(cycle.reset_by([Date.new(2026, 6, 1)]).notation).to eq("V1LE6M")
+      end
+
+      it "leaves a Calendar cycle alone — its window is fixed to the calendar" do
+        cycle = Cycle.for("V1C1Y")
+
+        expect(cycle.reset_by([Date.new(2026, 6, 1)]).notation).to eq("V1C1Y")
+      end
+
+      it "leaves a Within alone — a one-shot window does not repeat" do
+        cycle = Cycle.for("V2W3DF2026-01-01")
+
+        expect(cycle.reset_by([Date.new(2026, 1, 2)]).notation).to eq("V2W3DF2026-01-01")
+      end
+
+      it "leaves a volume-only cycle alone — it has no window" do
+        cycle = Cycle.for("V2")
+
+        expect(cycle.reset_by([Date.new(2026, 6, 1)]).notation).to eq("V2")
+      end
+
+      # Cycle.for wraps an un-anchored cycle in Cycles::Dormant, but a handler
+      # built directly skips that wrapper and still has no from date to move.
+      it "leaves an un-anchored cycle alone when built without the Dormant wrapper" do
+        cycle = Cycles::EndOf.new("V1E18M")
+
+        expect(cycle.reset_by([Date.new(2026, 6, 1)])).to eq(cycle)
+      end
+    end
+  end
+
+  RSpec.describe Cycle, "#dormant_capable?", type: :value do
+    # Reachable on every cycle, including the ones actually dormant — asking
+    # the class breaks there, because a dormant cycle is a Cycles::Dormant.
+    {
+      "V1E18M" => true, "V1E18MF2026-02-01" => true,
+      "V1I24M" => true, "V1I24MF2026-02-01" => true,
+      "V2W3D" => true,
+      "V1L180D" => false, "V1LE6M" => false, "V1C1Y" => false, "V2" => false
+    }.each do |notation, expected|
+      it "is #{expected} for #{notation}" do
+        expect(Cycle.for(notation).dormant_capable?).to be(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why

sof-cycle models recurring windows but stops short of resetting them, and says so four times in its own source:

- `Cycles::EndOf` — *"Complete 1 by that date to reset the cycle."*
- `Cycles::Interval` — *"After completion, the consuming app re-anchors from the completion date"*, repeated in its class comment, `description`, and `examples`.

So every consumer has to implement the re-anchoring itself, or get expiry wrong in the same way: an activated `V1E18M` expires 18 months after it was anchored and never recovers, however many completions land inside the window. A gem that ships a `dormant_capable?` concept and then documents four times that someone else must do the re-anchoring is describing a hole in its own API.

Trying to write that logic consumer-side surfaces a second problem:

```ruby
SOF::Cycle.for("V1E18M").class            # => SOF::Cycles::Dormant
SOF::Cycle.for("V1E18M").class.dormant_capable?
# => NoMethodError: undefined method 'dormant_capable?' for class SOF::Cycles::Dormant
```

`dormant_capable?` is a class method, dormant cycles are wrapped in `Cycles::Dormant`, and that wrapper's `method_missing` only forwards instance calls — so the predicate is unreachable on exactly the cycles that have it. Consumers are left enumerating `end_of? || interval?` by hand, which silently misses any kind added later.

## Summary

- `Cycle#reset_by(dates)` returns the window that now applies, given the acts folded so far. Dates on or before the current anchor are ignored so a back-dated act can't drag a forward-running window backwards; a date past a lapsed window restores it.
- Non-resetting kinds return `self`: a lookback window already slides, a calendar window is pinned to the calendar, `Within` is one-shot, and an un-anchored cycle has no window to move until it's activated. That's expressed as `recurring? && dormant_capable?` rather than an enumeration of kinds, so a future kind is covered by construction.
- `Cycle#dormant_capable?` gains an instance form that survives the `Dormant` wrapper.

`Cycles::Dormant#reset_by` is load-bearing rather than decorative: without it, `method_missing` forwards to the wrapped cycle and returns *that* object, so a caller would get back an unwrapped cycle whose `dormant?` is false.

Covered by `spec/sof/cycle_reset_spec.rb` — every kind, plus back-dating, lapse-restore, nil/`Time` tolerance, and a handler built directly rather than through `Cycle.for` (which skips the `Dormant` wrapper and has a nil `from_date`).
